### PR TITLE
Add TelegramClient cache accessor

### DIFF
--- a/bot/auth.py
+++ b/bot/auth.py
@@ -41,6 +41,14 @@ class AuthManager:
             self._session_path(uid), settings.API_ID, settings.API_HASH
         )
 
+    def client(self, uid: int) -> TelegramClient:
+        """Return cached or new TelegramClient for this user."""
+        return (
+            self._active.get(uid)
+            or self._pending.get(uid)
+            or self._new_client(uid)
+        )
+
     # ------------------------------------------------------------------ #
     # public API                                                         #
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- implement `AuthManager.client` helper for cached TelegramClient access

## Testing
- `python -m py_compile bot/auth.py bot/forwarding.py bot/routers/auth.py bot/routers/sources.py bot/routers/filters.py bot/routers/targets.py bot/entry.py bot/db.py bot/runtime.py bot/keyboards.py bot/logger.py bot/utils.py bot/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686844094c7c8322b42a4c22d5de145a