### PR TITLE
Enforce required config variables

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -15,7 +15,8 @@ class Settings:
 
     # Runtime sanity‑checks
     def validate(self):
-        missing = [k for k, v in self.__dict__.items() if v in (None, "")]
+        required = ["BOT_TOKEN", "API_ID", "API_HASH"]
+        missing = [k for k in required if not getattr(self, k)]
         if missing:
             raise RuntimeError(f"Missing required settings: {missing}")
 


### PR DESCRIPTION
## Summary
- update settings validation to check required BOT_TOKEN, API_ID, and API_HASH

## Testing
- `python3 -m py_compile bot/config.py`


------
https://chatgpt.com/codex/tasks/task_e_686844126f188322a62cb593f59df87c