### PR TITLE
Configure DB path for persistent volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Telegram Forwarder Bot
+
+This project runs a Telegram message forwarding bot.
+
+The `docker-compose.yml` file mounts a local `data/` directory inside the
+container at `/app/data` and sets `DB_PATH=/app/data/bot.db` so the SQLite
+database persists across restarts.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build: .
     env_file:
       - .env
+    environment:
+      # Store database inside the mounted data volume
+      DB_PATH: /app/data/bot.db
     volumes:
       - ./data:/app/data
       - ./sessions:/app/sessions


### PR DESCRIPTION
## Summary
- set `DB_PATH=/app/data/bot.db` in docker-compose
- document the volume and DB path in a new README

## Testing
- `pre-commit run --files docker-compose.yml README.md bot/config.py bot/db.py Dockerfile`
- *(docker unavailable: `docker compose up -d` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68684ba39de483229a199c77962dcac8