### PR TITLE
Remove redundant db/auth instantiation

### DIFF
--- a/bot/entry.py
+++ b/bot/entry.py
@@ -17,8 +17,6 @@ from bot import runtime as r
 
 from bot.config import settings
 from bot.logger import logger
-from bot.db import Database
-from bot.auth import AuthManager
 from bot.forwarding import ForwardManager
 
 from bot.routers.auth import router as auth_router
@@ -31,8 +29,6 @@ from bot.routers.misc    import router as misc_router
 # Instantiate core services (singletons shared across the package)
 # ----------------------------------------------------------------------------
 
-db = Database()
-auth = AuthManager()
 
 bot = Bot(
     settings.BOT_TOKEN,


### PR DESCRIPTION
## Summary
- stop instantiating `Database` and `AuthManager` in `entry.py`
- clean up unused imports

## Testing
- `ruff check bot/entry.py`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68684baa0e2483228571a71cc084d0f7